### PR TITLE
Add Rosetta Code Problem examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 generate-build
 example
+rosetta-example

--- a/examples/index.md
+++ b/examples/index.md
@@ -6,6 +6,11 @@ The centralized place to find your up-to-date, roc-expert-approved answer for "H
 ## Examples
 - [Json - Basic](/json-basic/README.html)
 - [Parser - Basic](/parser-basic/README.html)
+- [Rosetta Code Problem - A+B](/rosetta/AplusB/README.html)
+- [Rosetta Code Problem - Arithmetic](/rosetta/Arithmetic/README.html)
+- [Rosetta Code Problem - FizzBuzz](/rosetta/FizzBuzz/README.html)
+- [Rosetta Code Problem - Least Square Difference](/rosetta/LeastSquares/README.html)
+- [Rosetta Code Problem - Towers of Hanoi](/rosetta/TowersOfHanoi/README.html)
 
 ## Feedback
 

--- a/examples/rosetta/AplusB/README.md
+++ b/examples/rosetta/AplusB/README.md
@@ -1,0 +1,18 @@
+
+# Rosetta Code - A+B 
+
+This is a Roc solution for the [Rosetta Code A+B Problem](https://rosettacode.org/wiki/A%2BB)
+
+> *Given two integers, A and B. Their sum needs to be calculated.*
+
+## Output
+
+```
+% roc run main.roc -- 20 12
+The sum of 20 and 12 is 32
+```
+
+## Code
+```roc
+file:main.roc
+```

--- a/examples/rosetta/AplusB/main.roc
+++ b/examples/rosetta/AplusB/main.roc
@@ -1,0 +1,54 @@
+app "rosetta-example"
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    imports [
+        pf.Stdout,
+        pf.Task,
+        pf.Arg,
+        Str,
+    ]
+    provides [main] to pf
+
+TaskErrors : [InvalidArg, InvalidNumStr]
+
+main =
+    task =
+        args <- readArgs |> Task.await
+
+        sum = args.a + args.b
+        aStr = args.a |> Num.toStr
+        bStr = args.b |> Num.toStr
+        sumStr = sum |> Num.toStr
+
+        Task.succeed "The sum of \(aStr) and \(bStr) is \(sumStr)"
+
+    taskResult <- Task.attempt task
+
+    when taskResult is
+        Ok result -> Stdout.line result
+        Err InvalidArg -> Stdout.line "Error: Please provide two integers between -1000 and 1000 as arguments."
+        Err InvalidNumStr -> Stdout.line "Error: Invalid number format. Please provide two integers between -1000 and 1000."
+
+## Reads two command-line arguments, attempts to parse them as `I32` numbers,
+## and returns a task containing a record with two fields, `a` and `b`, holding
+## the parsed `I32` values.
+##
+## If the arguments are missing, if there's an issue with parsing the arguments
+## as `I32` numbers, or if the parsed numbers are outside the expected range
+## (-1000 to 1000), the function will return a task that fails with an
+## error `InvalidArg` or `InvalidNumStr`.
+readArgs : Task.Task { a : I32, b : I32 } TaskErrors
+readArgs =
+    Arg.list
+    |> Task.mapFail \_ -> InvalidArg
+    |> Task.await \args ->
+        aResult = List.get args 1 |> Result.try Str.toI32
+        bResult = List.get args 2 |> Result.try Str.toI32
+
+        when (aResult, bResult) is
+            (Ok a, Ok b) ->
+                if a < -1000 || a > 1000 || b < -1000 || b > 1000 then
+                    Task.fail InvalidNumStr
+                else
+                    Task.succeed { a, b }
+
+            _ -> Task.fail InvalidNumStr

--- a/examples/rosetta/Arithmetic/README.md
+++ b/examples/rosetta/Arithmetic/README.md
@@ -1,0 +1,22 @@
+# Rosetta Code - Arithmetic
+
+This is a Roc solution for the [Rosetta Code Arithmetic Problem](https://rosettacode.org/wiki/Arithmetic/Integer)
+
+> *Get two integers from the command line and display their: Sum, Difference, Product, Quotient, Remainder, and Exponentiation.*
+
+## Output
+
+```
+% roc run main.roc -- 20 4
+sum: 24
+difference: 16
+product: 80
+integer quotient: 5
+remainder: 0
+exponentiation: 160000
+```
+
+## Code
+```roc
+file:main.roc
+```

--- a/examples/rosetta/Arithmetic/main.roc
+++ b/examples/rosetta/Arithmetic/main.roc
@@ -1,0 +1,66 @@
+app "rosetta-example"
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    imports [
+        pf.Stdout,
+        pf.Task,
+        pf.Arg,
+        Str,
+    ]
+    provides [main] to pf
+
+TaskErrors : [InvalidArg, InvalidNumStr]
+
+main =
+    task =
+        args <- readArgs |> Task.await
+
+        results = [
+            ("sum", args.a + args.b),
+            ("difference", args.a - args.b),
+            ("product", args.a * args.b),
+            ("integer quotient", args.a // args.b),
+            ("remainder", args.a % args.b),
+            ("exponentiation", Num.powInt args.a args.b),
+        ]
+
+        resultsStr =
+            results
+            |> List.map
+                (\(operation, result) ->
+                    resultStr = result |> Num.toStr
+                    "\(operation): \(resultStr)")
+            |> Str.joinWith "\n"
+
+        Task.succeed resultsStr
+
+    taskResult <- Task.attempt task
+
+    when taskResult is
+        Ok result -> Stdout.line result
+        Err InvalidArg -> Stdout.line "Error: Please provide two integers between -1000 and 1000 as arguments."
+        Err InvalidNumStr -> Stdout.line "Error: Invalid number format. Please provide integers between -1000 and 1000."
+
+## Reads two command-line arguments, attempts to parse them as `I32` numbers,
+## and returns a task containing a record with two fields, `a` and `b`, holding
+## the parsed `I32` values.
+##
+## If the arguments are missing, if there's an issue with parsing the arguments
+## as `I32` numbers, or if the parsed numbers are outside the expected range
+## (-1000 to 1000), the function will return a task that fails with an
+## error `InvalidArg` or `InvalidNumStr`.
+readArgs : Task.Task { a : I32, b : I32 } TaskErrors
+readArgs =
+    Arg.list
+    |> Task.mapFail \_ -> InvalidArg
+    |> Task.await \args ->
+        aResult = List.get args 1 |> Result.try Str.toI32
+        bResult = List.get args 2 |> Result.try Str.toI32
+
+        when (aResult, bResult) is
+            (Ok a, Ok b) ->
+                if a < -1000 || a > 1000 || b < -1000 || b > 1000 then
+                    Task.fail InvalidNumStr
+                else
+                    Task.succeed { a, b }
+
+            _ -> Task.fail InvalidNumStr

--- a/examples/rosetta/FizzBuzz/README.md
+++ b/examples/rosetta/FizzBuzz/README.md
@@ -1,0 +1,21 @@
+
+# Rosetta Code - FizzBuzz
+
+This is a Roc solution for the [Rosetta Code FizzBuzz Problem](https://rosettacode.org/wiki/FizzBuzz).
+
+> *Print the integers from 1 to 100, replacing; multiples of three with "Fizz"; multiples of five with "Buzz"; multiples of both three and five with "FizzBuzz".*
+
+## Output 
+
+Run this app with `roc run main.roc` to print the FizzBuzz sequence, or
+run unit tests with `roc test main.roc`.
+
+```
+% roc run main.roc
+1,2,Fizz,4,Buzz,Fizz,7,8,Fizz,Buzz,11,Fizz,13,14,FizzBuzz,16,17,Fizz,19,Buzz,Fizz,22,23,Fizz,Buzz,26,Fizz,28,29,FizzBuzz,31,32,Fizz,34,Buzz,Fizz,37,38,Fizz,Buzz,41,Fizz,43,44,FizzBuzz,46,47,Fizz,49,Buzz,Fizz,52,53,Fizz,Buzz,56,Fizz,58,59,FizzBuzz,61,62,Fizz,64,Buzz,Fizz,67,68,Fizz,Buzz,71,Fizz,73,74,FizzBuzz,76,77,Fizz,79,Buzz,Fizz,82,83,Fizz,Buzz,86,Fizz,88,89,FizzBuzz,91,92,Fizz,94,Buzz,Fizz,97,98,Fizz,Buzz
+```
+
+## Code
+```roc
+file:main.roc
+```

--- a/examples/rosetta/FizzBuzz/main.roc
+++ b/examples/rosetta/FizzBuzz/main.roc
@@ -1,0 +1,46 @@
+app "rosetta-example"
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    imports [
+        pf.Stdout,
+        Str,
+    ]
+    provides [main] to pf
+
+main =
+    List.range { start: At 1, end: At 100 }
+    |> List.map fizzBuzz
+    |> Str.joinWith ","
+    |> Stdout.line
+
+## Determine the FizzBuzz value for a given integer. Returns "Fizz" for multiples
+## of 3, "Buzz" for multiples of 5, "FizzBuzz" for multiples of both 3 and 5,
+## and the original number as a string for all other values.
+fizzBuzz : I32 -> Str
+fizzBuzz = \n ->
+    fizz = Num.rem n 3 == 0
+    buzz = Num.rem n 5 == 0
+
+    if fizz && buzz then
+        "FizzBuzz"
+    else if fizz && !buzz then
+        "Fizz"
+    else if !fizz && buzz then
+        "Buzz"
+    else
+        Num.toStr n
+
+## Test Case 1: not a multiple of 3 or 5
+expect fizzBuzz 1 == "1"
+expect fizzBuzz 7 == "7"
+
+## Test Case 2: multiple of 3
+expect fizzBuzz 3 == "Fizz"
+expect fizzBuzz 9 == "Fizz"
+
+## Test Case 3: multiple of 5
+expect fizzBuzz 5 == "Buzz"
+expect fizzBuzz 20 == "Buzz"
+
+## Test Case 4: multiple of both 3 and 5
+expect fizzBuzz 15 == "FizzBuzz"
+expect fizzBuzz 45 == "FizzBuzz"

--- a/examples/rosetta/LeastSquares/README.md
+++ b/examples/rosetta/LeastSquares/README.md
@@ -1,0 +1,21 @@
+
+# Rosetta Code - Least Square Difference
+
+This is a Roc solution for the [Rosetta Code Find Square Difference Problem](https://rosettacode.org/wiki/Find_square_difference)
+
+> *Find the least positive integer number `n`, where the difference of `n*n` and 
+`(n-1)*(n-1)` is greater than 1000.*
+
+## Output 
+
+```
+% roc run main.roc      
+The least positive integer n, where the difference of n*n and (n-1)*(n-1) is greater than 1000, is 501
+```
+
+Run unit tests with `roc test main.roc`
+
+## Code
+```roc
+file:main.roc
+```

--- a/examples/rosetta/LeastSquares/main.roc
+++ b/examples/rosetta/LeastSquares/main.roc
@@ -1,0 +1,29 @@
+app "rosetta-example"
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    imports [
+        pf.Stdout,
+    ]
+    provides [main] to pf
+
+main =
+    nStr = findNumber 1 |> Num.toStr
+
+    Stdout.line "The least positive integer n, where the difference of n*n and (n-1)*(n-1) is greater than 1000, is \(nStr)"
+
+## A recursive function that takes an `U32` as its input and returns the least
+## positive integer number `n`, where the difference of `n*n` and `(n-1)*(n-1)`
+## is greater than 1000.
+##
+## The input `n` should be a positive integer, and the function will return an
+## `U32`representing the least positive integer that satisfies the condition.
+##
+findNumber : U32 -> U32
+findNumber = \n ->
+    difference = Num.sub (Num.powInt n 2) (Num.powInt (n - 1) 2)
+
+    if difference > 1000 then
+        n
+    else
+        findNumber (n + 1)
+
+expect findNumber 1 == 501

--- a/examples/rosetta/TowersOfHanoi/README.md
+++ b/examples/rosetta/TowersOfHanoi/README.md
@@ -1,0 +1,24 @@
+
+# Rosetta Code - Towers of Hanoi 
+
+This is a Roc solution for the [Rosetta Code Towers of Hanoi Problem](https://en.wikipedia.org/wiki/Tower_of_Hanoi) task.
+
+> *Solve the Towers of Hanoi problem using recursion.*
+
+## Output
+
+```
+% roc run main.roc -- 3
+Move disk from A to B
+Move disk from A to C
+Move disk from B to C
+Move disk from A to B
+Move disk from C to A
+Move disk from C to B
+Move disk from A to B
+```
+
+## Code
+```roc
+file:main.roc
+```

--- a/examples/rosetta/TowersOfHanoi/main.roc
+++ b/examples/rosetta/TowersOfHanoi/main.roc
@@ -1,0 +1,71 @@
+app "rosetta-example"
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    imports [
+        pf.Stdout,
+        pf.Task,
+        pf.Arg,
+        Str,
+    ]
+    provides [main] to pf
+
+TaskErrors : [InvalidArg, InvalidNumStr]
+
+main =
+    task =
+        args <- readArgs |> Task.await
+
+        hanoi args.numDisks "A" "B" "C" []
+        |> List.map \(from, to) -> "Move disk from \(from) to \(to)"
+        |> Str.joinWith "\n"
+        |> Task.succeed
+
+    taskResult <- Task.attempt task
+
+    when taskResult is
+        Ok result -> Stdout.line result
+        Err InvalidArg -> Stdout.line "Error: Please provide the number of disks as an argument."
+        Err InvalidNumStr -> Stdout.line "Error: Invalid number format. Please provide a positive integer."
+
+readArgs : Task.Task { numDisks : U32 } TaskErrors
+readArgs =
+    Arg.list
+    |> Task.mapFail \_ -> InvalidArg
+    |> Task.await \args ->
+        numDisksResult = List.get args 1 |> Result.try Str.toU32
+
+        when numDisksResult is
+            Ok numDisks ->
+                if numDisks < 1 then
+                    Task.fail InvalidNumStr
+                else
+                    Task.succeed { numDisks }
+
+            _ -> Task.fail InvalidNumStr
+
+## Solves the Tower of Hanoi problem using recursion.
+##
+## `numDisks` - The number of disks in the Tower of Hanoi problem.
+## `from` - The identifier of the source rod.
+## `to` - The identifier of the target rod.
+## `using` - The identifier of the auxiliary rod.
+## `moves` - A list of moves accumulated so far.
+##
+## Returns a list of moves (tuples) to solve the Tower of Hanoi problem.
+##
+hanoi = \numDisks, from, to, using, moves ->
+    if numDisks == 1 then
+        List.concat moves [(from, to)]
+    else
+        moves1 = hanoi (numDisks - 1) from using to moves
+        moves2 = List.concat moves1 [(from, to)]
+
+        hanoi (numDisks - 1) using to from moves2
+
+## Test Case 1: Tower of Hanoi with 1 disk
+expect hanoi 1 "A" "B" "C" [] == [("A", "B")]
+
+## Test Case 2: Tower of Hanoi with 2 disks
+expect hanoi 2 "A" "B" "C" [] == [("A", "C"), ("A", "B"), ("C", "B")]
+
+## Test Case 3: Tower of Hanoi with 3 disks
+expect hanoi 3 "A" "B" "C" [] == [("A", "B"), ("A", "C"), ("B", "C"), ("A", "B"), ("C", "A"), ("C", "B"), ("A", "B")]

--- a/www/styles.css
+++ b/www/styles.css
@@ -603,19 +603,42 @@ samp .comment,
 code .comment {
   color: var(--green);
 }
-/* Number, String, Tag, Type literals */
+
+/* Number, String, Tag literals */
+samp .storage.type,
+code .storage.type,
+samp .string,
+code .string,
+samp .string.begin,
+code .string.begin,
+samp .string.end,
+code .string.end,
+samp .constant,
+code .constant,
 samp .literal,
 code .literal {
   color: var(--cyan);
 }
+
 /* Keywords and punctuation */
-samp .kw,
+samp .keyword, 
+code .keyword,
+samp .punctuation.section, 
+code .punctuation.section,
+samp .punctuation.separator, 
+code .punctuation.separator,
+samp .punctuation.terminator, 
+code .punctuation.terminator,
+samp .kw, 
 code .kw {
-  color: var(--magenta);
+    color: var(--magenta);
 }
+
 /* Operators */
 samp .op,
-code .op {
+code .op,
+samp .keyword.operator,
+code .keyword.operator {
   color: var(--orange);
 }
 
@@ -626,12 +649,22 @@ code .delimeter {
 }
 
 /* Variables modules and field names */
+samp .function,
+code .function,
+samp .meta.group,
+code .meta.group,
+samp .meta.block,
+code .meta.block,
 samp .lowerident,
 code .lowerident {
   color: var(--blue);
 }
 
 /* Types, Tags, and Modules */
+samp .type,
+code .type,
+samp .meta.path,
+code .meta.path,
 samp .upperident,
 code .upperident {
   color: var(--green);


### PR DESCRIPTION
This PR adds a number of new examples (links to problem description);
- [Rosetta Code A+B Problem](https://rosettacode.org/wiki/A%2BB)
- [Rosetta Code Arithmetic Problem](https://rosettacode.org/wiki/Arithmetic/Integer)
- [Rosetta Code FizzBuzz Problem](https://rosettacode.org/wiki/FizzBuzz)
- [Rosetta Code Find Square Difference Problem](https://rosettacode.org/wiki/Find_square_difference)
- [Rosetta Code Towers of Hanoi Problem](https://en.wikipedia.org/wiki/Tower_of_Hanoi)

Updates `index.md` to link these new examples.

Updates `.css` file to support highlighting of other languages (not currently used)