### PR TITLE
Unify naming of examples

### DIFF
--- a/examples/Arithmetic/README.md
+++ b/examples/Arithmetic/README.md
@@ -1,4 +1,4 @@
-# Problem - Arithmetic
+# Arithmetic
 
 This is a Roc solution for the following task;
 

--- a/examples/FizzBuzz/README.md
+++ b/examples/FizzBuzz/README.md
@@ -1,5 +1,5 @@
 
-# Problem - FizzBuzz
+# FizzBuzz
 
 This is a Roc solution for the popular [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview problem;
 

--- a/examples/LeastSquares/README.md
+++ b/examples/LeastSquares/README.md
@@ -1,5 +1,5 @@
 
-# Problem - Least Square Difference
+# Least Square Difference
 
 This is a Roc solution for the following [Least Squares](https://en.wikipedia.org/wiki/Least_squares) problem.
 

--- a/examples/TowersOfHanoi/README.md
+++ b/examples/TowersOfHanoi/README.md
@@ -1,5 +1,5 @@
 
-# Problem - Towers of Hanoi 
+# Towers of Hanoi 
 
 This is a Roc solution for the popular [Towers of Hanoi](https://en.wikipedia.org/wiki/Tower_of_Hanoi) problem.
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -7,12 +7,12 @@ The centralized place to find your up-to-date, roc-expert-approved answer for "H
 - [Hello World](/HelloWorld/README.html)
 - [Pattern Matching](/PatternMatching/README.html)
 - [Graph Traversal](/GraphTraversal/README.html)
-- [Json - Basic](/json-basic/README.html)
-- [Parser - Basic](/parser-basic/README.html)
-- [Problem - Arithmetic](/Arithmetic/README.html)
-- [Problem - FizzBuzz](/FizzBuzz/README.html)
-- [Problem - Least Square Difference](/LeastSquares/README.html)
-- [Problem - Towers of Hanoi](/TowersOfHanoi/README.html)
+- [Json](/json-basic/README.html)
+- [Parser](/parser-basic/README.html)
+- [Arithmetic](/Arithmetic/README.html)
+- [FizzBuzz](/FizzBuzz/README.html)
+- [Least Square Difference](/LeastSquares/README.html)
+- [Towers of Hanoi](/TowersOfHanoi/README.html)
 
 ## Feedback
 

--- a/examples/json-basic/README.md
+++ b/examples/json-basic/README.md
@@ -1,4 +1,4 @@
-# Json - Basic
+# Json
 
 How to serialise and de-serialise data to and from json using the `Encode` and `Decode` abilities.
 

--- a/examples/parser-basic/README.md
+++ b/examples/parser-basic/README.md
@@ -1,4 +1,4 @@
-# Parser - Basic
+# Parser
 
 A custom [parser](https://www.techopedia.com/definition/3854/parser) for counting letters.
 


### PR DESCRIPTION
Updates the names of examples so they are more consistent, which looks better.

<img width="289" alt="Screen Shot 2023-04-18 at 06 45 32" src="https://user-images.githubusercontent.com/2679227/232606805-e9101dfe-326d-43d8-a820-6b75e7384f71.png">
