### PR TITLE
Update basic-cli URL and Json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can run these examples using the [Roc cli](https://github.com/roc-lang/roc/t
 ## To view the examples site locally
 
 ```
-roc run main.roc -- examples build
+roc run main.roc -- examples build 
 ```
 
 Then copy the static assets from `/www` to `/build`.

--- a/examples/Arithmetic/main.roc
+++ b/examples/Arithmetic/main.roc
@@ -1,5 +1,5 @@
 app "arithmetic"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br" }
     imports [
         pf.Stdout,
         pf.Task.{ await },

--- a/examples/FizzBuzz/main.roc
+++ b/examples/FizzBuzz/main.roc
@@ -1,5 +1,5 @@
 app "fizz-buzz"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br" }
     imports [
         pf.Stdout,
     ]

--- a/examples/HelloWorld/main.roc
+++ b/examples/HelloWorld/main.roc
@@ -1,5 +1,5 @@
 app "hello-world"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br" }
     imports [pf.Stdout]
     provides [main] to pf
 

--- a/examples/JsonBasic/README.md
+++ b/examples/JsonBasic/README.md
@@ -1,12 +1,13 @@
 # Json
 
-How to serialise and de-serialise data to and from json using the `Encode` and `Decode` abilities.
+A basic example which shows how to de-serialise data from json using the `Decode` ability.
 
-## Platform: 
-[roc-lang/basic-cli 0.2.1 ](https://github.com/roc-lang/basic-cli/tree/0.2.1)
+## Output
 
-## Packages: 
-- [Json](https://github.com/lukewilliamboswell/roc-package-explorations/releases/download/0.0.1)
+```
+% roc run examples/JsonBasic/main.roc
+Successfully decoded image, title:"View from 15th Floor"
+```
 
 ## Code
 ```roc

--- a/examples/JsonBasic/main.roc
+++ b/examples/JsonBasic/main.roc
@@ -1,39 +1,37 @@
 app "json-basic"
     packages {
         cli: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br",
-        json: "https://github.com/lukewilliamboswell/roc-package-explorations/releases/download/0.0.1/cdKMia6cwdRG6Gb0SfXP8cgGF7yTz-i959FV6ZfuS0E.tar.br",
     }
     imports [
         cli.Stdout,
-        json.Core.{ Json, toUtf8, fromUtf8 },
-        Decode,
+        Json.{ jsonWithOptions },
+        Decode.{ DecodeResult, fromBytesPartial },
     ]
     provides [main] to cli
 
-main = Stdout.line "Hello \(person.name)!"
+main =
+    requestBody = Str.toUtf8 "{\"Image\":{\"Animated\":false,\"Height\":600,\"Ids\":[116,943,234,38793],\"Thumbnail\":{\"Height\":125,\"Url\":\"http:\\/\\/www.example.com\\/image\\/481989943\",\"Width\":100},\"Title\":\"View from 15th Floor\",\"Width\":800}}"
 
-Person : {
-    name : Str,
+    decoder = jsonWithOptions { fieldNameMapping: PascalCase }
+
+    decoded : DecodeResult ImageRequest
+    decoded = fromBytesPartial requestBody decoder
+
+    when decoded.result is
+        Ok record -> Stdout.line "Successfully decoded image, title:\"\(record.image.title)\""
+        Err _ -> crash "Error, failed to decode image"
+
+ImageRequest : {
+    image : {
+        width : I64,
+        height : I64,
+        title : Str,
+        thumbnail : {
+            url : Str,
+            height : F32,
+            width : F32,
+        },
+        animated : Bool,
+        ids : List U32,
+    },
 }
-
-inputStr : Str
-inputStr = "{\"name\":\"John Smith\"}"
-
-person : Person
-person =
-    inputStr
-    |> Str.toUtf8
-    |> Decode.fromBytes fromUtf8
-    |> Result.onErr \_ -> crash "bad decode"
-    |> Result.withDefault { name: "" }
-
-outputStr : Str
-outputStr =
-    person
-    |> Encode.toBytes toUtf8
-    |> Str.fromUtf8
-    |> Result.onErr \_ -> crash "bad encode"
-    |> Result.withDefault ""
-
-# Tests
-expect outputStr == inputStr

--- a/examples/LeastSquares/main.roc
+++ b/examples/LeastSquares/main.roc
@@ -1,5 +1,5 @@
 app "example"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br" }
     imports [
         pf.Stdout,
     ]

--- a/examples/RandomNumbers/main.roc
+++ b/examples/RandomNumbers/main.roc
@@ -1,6 +1,6 @@
 app "random-numbers"
     packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br",
         rand: "https://github.com/lukewilliamboswell/roc-random/releases/download/0.0.1/x_XwrgehcQI4KukXligrAkWTavqDAdE5jGamURpaX-M.tar.br",
     }
     imports [

--- a/examples/TowersOfHanoi/main.roc
+++ b/examples/TowersOfHanoi/main.roc
@@ -1,5 +1,5 @@
 app "towers-of-hanoi"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.1/97mY3sUwo433-pcnEQUlMhn-sWiIf_J9bPhcAFZoqY4.tar.br" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.3.2/tE4xS_zLdmmxmHwHih9kHWQ7fsXtJr7W7h3425-eZFk.tar.br" }
     imports [
         pf.Stdout,
         pf.Task.{ await },


### PR DESCRIPTION
This PR bumps the version on basic-cli URL platform, and also updates the Json example so that it is more interesting and uses the latest Json builtin.   