### PR TITLE
Rename parser digits to positiveInt and fix its bug

### DIFF
--- a/examples/Parser/package/ParserStr.roc
+++ b/examples/Parser/package/ParserStr.roc
@@ -15,7 +15,7 @@ interface ParserStr
         scalar,
         oneOf,
         digit,
-        digits,
+        positiveInt,
         strFromRaw,
     ]
     imports [
@@ -196,12 +196,12 @@ digit =
     oneOf digitParsers
 
 # NOTE: Currently happily accepts leading zeroes
-digits : Parser RawStr (Int *)
-digits =
+positiveInt : Parser RawStr (Int *)
+positiveInt =
     oneOrMore digit
     |> map \digitsList ->
         digitsList
-        |> List.map Num.intCast
+        |> List.map \char -> Num.intCast char - '0'
         |> List.walk 0 \sum, digitVal -> 10 * sum + digitVal
 
 ## Try a bunch of different parsers.


### PR DESCRIPTION
Fixes a bug in the parser example. See [this discussion](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Parser.20example.20digits)