### PR TITLE
add simple-http-server arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you're using the nix flake simple-http-server will already be installed. With
 View the website:
 ```
 cd ./build
-simple-http-server --nocache
+simple-http-server --nocache --index
 ```
 
 ## Ideas and Improvements


### PR DESCRIPTION
--index makes it so that you don't need to go explicitly to `/index.html`