### PR TITLE
Add negative cases to last pattern matching example

### DIFF
--- a/examples/PatternMatching/PatternMatching.roc
+++ b/examples/PatternMatching/PatternMatching.roc
@@ -74,4 +74,6 @@ expect
             [Foo, Count num, ..] if num > 0 -> FooBar
             _ -> Other
 
-    match [Foo, Count 1] == FooBar
+    (match [Foo, Count 1] == FooBar)
+    && (match [Foo, Count 0] != FooBar)
+    && (match [Baz, Count 1] != FooBar)


### PR DESCRIPTION
Added a couple of negative cases to the last example, in line with the previous examples.