### PR TITLE
don't run Roc build script in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,4 +53,5 @@ jobs:
 
       - run: ROC=./roc_nightly/roc ./ci_scripts/all_tests.sh
 
-      - run: ./roc_nightly/roc run main.roc -- examples build
+      # segfaults
+      # - run: ./roc_nightly/roc run main.roc -- examples build


### PR DESCRIPTION
This segfaults at the end of the run: `2807 Segmentation fault      (core dumped) ./roc_nightly/roc run main.roc -- examples build`