### PR TITLE
Mention known formatter/parser issue on Tasks example

### DIFF
--- a/examples/Tasks/README.md
+++ b/examples/Tasks/README.md
@@ -83,6 +83,8 @@ With our `Task.await` chain we can deal with errors at the end so it doesn't int
 
 The underscore (`_`) at the end of `[FailedToReadArgs]` is a temporary workaround for [an issue](https://github.com/roc-lang/roc/issues/5660).
 
+Note: running the formatter on the `readArgs` implementation currently results in a [parser issue](https://github.com/roc-lang/roc/issues/6074), so skip formatting as a temporary workaround until it's fixed.
+
 ### Fetch website content
 
 We'll use the `url` we obtained in the previous step and retrieve its contents:


### PR DESCRIPTION
Running the formatter on the Tasks example code (for instance when using the VS Code extension with [recommended settings](https://github.com/ivan-demchenko/roc-vscode-unofficial?tab=readme-ov-file#configuring-language-server) that format on save) results in a parser error on the `readArgs` implementation that was reported in https://github.com/roc-lang/roc/issues/6074 but not yet fixed

This adds a note that mentions this known issue, in case other readers run into this, which can later be removed once the bug is fixed