### PR TITLE
Update examples to use `!` syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ examples/CommandLineArgs/main
 examples/Tasks/main
 examples/Tuples/main
 examples/EncodeDecode/main
+examples/GoPlatform/platform/*.dylib
 roc_nightly/
 
 # macOS directory attributes

--- a/examples/Arithmetic/main.roc
+++ b/examples/Arithmetic/main.roc
@@ -50,9 +50,9 @@ main =
 readArgs : Task.Task { a : I32, b : I32 } TaskErrors
 readArgs =
 
-    args = 
+    args =
         Arg.list
-        |> Task.mapErr! \_ -> InvalidArg
+            |> Task.mapErr! \_ -> InvalidArg
 
     aResult = List.get args 1 |> Result.try Str.toI32
     bResult = List.get args 2 |> Result.try Str.toI32

--- a/examples/Arithmetic/main.roc
+++ b/examples/Arithmetic/main.roc
@@ -1,5 +1,5 @@
 app "arithmetic"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     imports [
         pf.Stdout,
         pf.Task,

--- a/examples/CommandLineArgs/main.roc
+++ b/examples/CommandLineArgs/main.roc
@@ -1,11 +1,10 @@
 # Run with `roc ./examples/CommandLineArgs/main.roc -- examples/CommandLineArgs/input.txt`
 app "command-line-args"
     packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br",
+        pf: "../../../basic-cli/platform/main.roc",
     }
     imports [
         pf.Stdout,
-        pf.Stderr,
         pf.File,
         pf.Path,
         pf.Task,
@@ -13,36 +12,34 @@ app "command-line-args"
     ]
     provides [main] to pf
 
-main : Task.Task {} I32
 main =
     finalTask =
         # try to read the first command line argument
-        pathArg <- Task.await readFirstArgT
+        pathArg = readFirstArgT!
 
         readFileToStr (Path.fromStr pathArg)
 
     finalResult <- Task.attempt finalTask
 
     when finalResult is
-        Err ZeroArgsGiven ->
-            {} <- Stderr.line "Error ZeroArgsGiven:\n\tI expected one argument, but I got none.\n\tRun the app like this: `roc command-line-args.roc -- path/to/input.txt`" |> Task.await
-
-            Task.err 1 # 1 is an exit code to indicate failure
+        Err ZeroArgsGiven -> 
+        
+            Task.err (Exit 1 "Error ZeroArgsGiven:\n\tI expected one argument, but I got none.\n\tRun the app like this: `roc command-line-args.roc -- path/to/input.txt`")
 
         Err (ReadFileErr errMsg) ->
             indentedErrMsg = indentLines errMsg
-            {} <- Stderr.line "Error ReadFileErr:\n$(indentedErrMsg)" |> Task.await
 
-            Task.err 1 # 1 is an exit code to indicate failure
+            Task.err (Exit 1 "Error ReadFileErr:\n$(indentedErrMsg)")
 
         Ok fileContentStr ->
+            
             Stdout.line "file content: $(fileContentStr)"
 
 # Task to read the first CLI arg (= Str)
 readFirstArgT : Task.Task Str [ZeroArgsGiven]_
 readFirstArgT =
     # read all command line arguments
-    args <- Arg.list |> Task.await
+    args = Arg.list!
 
     # get the second argument, the first is the executable's path
     List.get args 1 |> Result.mapErr (\_ -> ZeroArgsGiven) |> Task.fromResult

--- a/examples/CommandLineArgs/main.roc
+++ b/examples/CommandLineArgs/main.roc
@@ -22,8 +22,7 @@ main =
     finalResult <- Task.attempt finalTask
 
     when finalResult is
-        Err ZeroArgsGiven -> 
-        
+        Err ZeroArgsGiven ->
             Task.err (Exit 1 "Error ZeroArgsGiven:\n\tI expected one argument, but I got none.\n\tRun the app like this: `roc command-line-args.roc -- path/to/input.txt`")
 
         Err (ReadFileErr errMsg) ->
@@ -32,7 +31,6 @@ main =
             Task.err (Exit 1 "Error ReadFileErr:\n$(indentedErrMsg)")
 
         Ok fileContentStr ->
-            
             Stdout.line "file content: $(fileContentStr)"
 
 # Task to read the first CLI arg (= Str)

--- a/examples/CommandLineArgs/main.roc
+++ b/examples/CommandLineArgs/main.roc
@@ -1,7 +1,7 @@
 # Run with `roc ./examples/CommandLineArgs/main.roc -- examples/CommandLineArgs/input.txt`
 app "command-line-args"
     packages {
-        pf: "../../../basic-cli/platform/main.roc",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
     }
     imports [
         pf.Stdout,

--- a/examples/EncodeDecode/main.roc
+++ b/examples/EncodeDecode/main.roc
@@ -1,6 +1,6 @@
 app "example"
     packages {
-        pf: "../../../basic-cli/platform/main.roc",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
         json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.7.0/xuaMzXRVG_SEhOFZucS3iBozlRdObWsfKaYZMHVE_q0.tar.br",
     }
     imports [

--- a/examples/EncodeDecode/main.roc
+++ b/examples/EncodeDecode/main.roc
@@ -1,10 +1,11 @@
 app "example"
     packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br",
+        pf: "../../../basic-cli/platform/main.roc",
         json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.7.0/xuaMzXRVG_SEhOFZucS3iBozlRdObWsfKaYZMHVE_q0.tar.br",
     }
     imports [
         pf.Stdout.{ line },
+        pf.Task,
         json.Core.{ json },
         Decode.{ Decoder, DecoderFormatting, DecodeResult, DecodeError },
         Encode.{ Encoder, EncoderFormatting },

--- a/examples/FizzBuzz/main.roc
+++ b/examples/FizzBuzz/main.roc
@@ -1,5 +1,5 @@
 app "fizz-buzz"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     imports [pf.Stdout, pf.Task]
     provides [main] to pf
 

--- a/examples/FizzBuzz/main.roc
+++ b/examples/FizzBuzz/main.roc
@@ -1,6 +1,6 @@
 app "fizz-buzz"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br" }
-    imports [pf.Stdout]
+    packages { pf: "../../../basic-cli/platform/main.roc" }
+    imports [pf.Stdout, pf.Task]
     provides [main] to pf
 
 main =

--- a/examples/HelloWorld/main.roc
+++ b/examples/HelloWorld/main.roc
@@ -3,5 +3,5 @@ app "hello-world"
     imports [pf.Stdout, pf.Task]
     provides [main] to pf
 
-main = 
+main =
     Stdout.line! "Hello, World!"

--- a/examples/HelloWorld/main.roc
+++ b/examples/HelloWorld/main.roc
@@ -1,5 +1,5 @@
 app "hello-world"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     imports [pf.Stdout, pf.Task]
     provides [main] to pf
 

--- a/examples/HelloWorld/main.roc
+++ b/examples/HelloWorld/main.roc
@@ -1,6 +1,7 @@
 app "hello-world"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br" }
-    imports [pf.Stdout]
+    packages { pf: "../../../basic-cli/platform/main.roc" }
+    imports [pf.Stdout, pf.Task]
     provides [main] to pf
 
-main = Stdout.line "Hello, World!"
+main = 
+    Stdout.line! "Hello, World!"

--- a/examples/IngestFiles/main.roc
+++ b/examples/IngestFiles/main.roc
@@ -1,10 +1,11 @@
 app "ingested-file"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br" }
+    packages { pf: "../../../basic-cli/platform/main.roc" }
     imports [
         pf.Stdout,
+        pf.Task,
         "sample.txt" as sample : Str,
     ]
     provides [main] to pf
 
 main =
-    Stdout.line "$(sample)"
+    Stdout.line! "$(sample)"

--- a/examples/IngestFiles/main.roc
+++ b/examples/IngestFiles/main.roc
@@ -1,5 +1,5 @@
 app "ingested-file"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     imports [
         pf.Stdout,
         pf.Task,

--- a/examples/Json/main.roc
+++ b/examples/Json/main.roc
@@ -1,6 +1,6 @@
 app "json-basic"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br",
+        cli: "../../../basic-cli/platform/main.roc",
         json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.7.0/xuaMzXRVG_SEhOFZucS3iBozlRdObWsfKaYZMHVE_q0.tar.br",
     }
     imports [
@@ -24,13 +24,8 @@ main =
     decoded = fromBytesPartial requestBody decoder
 
     when decoded.result is
-        Ok record ->
-            Stdout.line "Successfully decoded image, title:\"$(record.image.title)\""
-
-        Err _ ->
-            {} <- Stdout.line "Error, failed to decode image" |> Task.await
-
-            Task.err 1 # 1 is an exit code to indicate failure
+        Ok record -> Stdout.line "Successfully decoded image, title:\"$(record.image.title)\""
+        Err _ -> Task.err (Exit 1 "Error, failed to decode image")
 
 ImageRequest : {
     image : {

--- a/examples/Json/main.roc
+++ b/examples/Json/main.roc
@@ -1,6 +1,6 @@
 app "json-basic"
     packages {
-        cli: "../../../basic-cli/platform/main.roc",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
         json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.7.0/xuaMzXRVG_SEhOFZucS3iBozlRdObWsfKaYZMHVE_q0.tar.br",
     }
     imports [

--- a/examples/LeastSquares/main.roc
+++ b/examples/LeastSquares/main.roc
@@ -1,5 +1,5 @@
 app "example"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     imports [
         pf.Stdout,
         pf.Task,

--- a/examples/LeastSquares/main.roc
+++ b/examples/LeastSquares/main.roc
@@ -1,7 +1,8 @@
 app "example"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br" }
+    packages { pf: "../../../basic-cli/platform/main.roc" }
     imports [
         pf.Stdout,
+        pf.Task,
     ]
     provides [main] to pf
 

--- a/examples/MultipleRocFiles/main.roc
+++ b/examples/MultipleRocFiles/main.roc
@@ -4,5 +4,5 @@ app "interface-modules"
     imports [pf.Stdout, pf.Task, Hello]
     provides [main] to pf
 
-main = 
+main =
     Stdout.line! (Hello.hello "World")

--- a/examples/MultipleRocFiles/main.roc
+++ b/examples/MultipleRocFiles/main.roc
@@ -1,7 +1,8 @@
 app "interface-modules"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br" }
+    packages { pf: "../../../basic-cli/platform/main.roc" }
     # we import Stdout from the platform and the Hello interface from the Hello.roc file
-    imports [pf.Stdout, Hello]
+    imports [pf.Stdout, pf.Task, Hello]
     provides [main] to pf
 
-main = Stdout.line (Hello.hello "World")
+main = 
+    Stdout.line! (Hello.hello "World")

--- a/examples/MultipleRocFiles/main.roc
+++ b/examples/MultipleRocFiles/main.roc
@@ -1,5 +1,5 @@
 app "interface-modules"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     # we import Stdout from the platform and the Hello interface from the Hello.roc file
     imports [pf.Stdout, pf.Task, Hello]
     provides [main] to pf

--- a/examples/Parser/main.roc
+++ b/examples/Parser/main.roc
@@ -13,11 +13,11 @@ app "parser-basic"
 
 main =
     many letterParser
-    |> parseStr inputStr
-    |> Result.map countLetterAs
-    |> Result.map \count -> "I counted $(count) letter A's!"
-    |> Result.withDefault "Ooops, something went wrong parsing"
-    |> Stdout.line!
+        |> parseStr inputStr
+        |> Result.map countLetterAs
+        |> Result.map \count -> "I counted $(count) letter A's!"
+        |> Result.withDefault "Ooops, something went wrong parsing"
+        |> Stdout.line!
 
 Letter : [A, B, C, Other]
 

--- a/examples/Parser/main.roc
+++ b/examples/Parser/main.roc
@@ -1,10 +1,11 @@
 app "parser-basic"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br",
+        cli: "../../../basic-cli/platform/main.roc",
         parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5.2/9VrPjwfQQ1QeSL3CfmWr2Pr9DESdDIXy97pwpuq84Ck.tar.br",
     }
     imports [
         cli.Stdout,
+        cli.Task,
         parser.Core.{ Parser, many, oneOf, map },
         parser.String.{ parseStr, codeunit, anyCodeunit },
     ]
@@ -16,7 +17,7 @@ main =
     |> Result.map countLetterAs
     |> Result.map \count -> "I counted $(count) letter A's!"
     |> Result.withDefault "Ooops, something went wrong parsing"
-    |> Stdout.line
+    |> Stdout.line!
 
 Letter : [A, B, C, Other]
 

--- a/examples/Parser/main.roc
+++ b/examples/Parser/main.roc
@@ -1,6 +1,6 @@
 app "parser-basic"
     packages {
-        cli: "../../../basic-cli/platform/main.roc",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
         parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5.2/9VrPjwfQQ1QeSL3CfmWr2Pr9DESdDIXy97pwpuq84Ck.tar.br",
     }
     imports [

--- a/examples/RandomNumbers/main.roc
+++ b/examples/RandomNumbers/main.roc
@@ -27,7 +27,6 @@ main =
         result.numbers
         |> List.map Num.toStr
         |> Str.joinWith ","
-
     Stdout.line! "Random numbers are: $(numbersListStr)"
 
 # Generate a list of numbers using the seed and generator provided

--- a/examples/RandomNumbers/main.roc
+++ b/examples/RandomNumbers/main.roc
@@ -1,6 +1,6 @@
 app "random-numbers"
     packages {
-        pf: "../../../basic-cli/platform/main.roc",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
         rand: "https://github.com/lukewilliamboswell/roc-random/releases/download/0.0.1/x_XwrgehcQI4KukXligrAkWTavqDAdE5jGamURpaX-M.tar.br",
     }
     imports [

--- a/examples/RandomNumbers/main.roc
+++ b/examples/RandomNumbers/main.roc
@@ -1,10 +1,11 @@
 app "random-numbers"
     packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br",
+        pf: "../../../basic-cli/platform/main.roc",
         rand: "https://github.com/lukewilliamboswell/roc-random/releases/download/0.0.1/x_XwrgehcQI4KukXligrAkWTavqDAdE5jGamURpaX-M.tar.br",
     }
     imports [
         pf.Stdout,
+        pf.Task,
         rand.Random,
     ]
     provides [main] to pf
@@ -27,7 +28,7 @@ main =
         |> List.map Num.toStr
         |> Str.joinWith ","
 
-    Stdout.line "Random numbers are: $(numbersListStr)"
+    Stdout.line! "Random numbers are: $(numbersListStr)"
 
 # Generate a list of numbers using the seed and generator provided
 # This is NOT cryptograhpically secure!

--- a/examples/TaskLoop/README.md
+++ b/examples/TaskLoop/README.md
@@ -32,7 +32,7 @@ I64 -> Task [Done I64, Step I64] [NotNum Str]
 This is where the action happens:
 ```roc
 addNumberFromStdin = \sum ->
-    input <- Stdin.line |> Task.await
+    input = Stdin.line!
 
     addResult =
         when input is

--- a/examples/TaskLoop/main.roc
+++ b/examples/TaskLoop/main.roc
@@ -1,6 +1,6 @@
 app "task-usage"
     packages {
-        pf: "../../../basic-cli/platform/main.roc",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
     }
     imports [pf.Stdin, pf.Stdout, pf.Stderr, pf.Task.{ Task }]
     provides [main] to pf

--- a/examples/TaskLoop/main.roc
+++ b/examples/TaskLoop/main.roc
@@ -11,25 +11,23 @@ run : Task {} _
 run =
     Stdout.line! "Enter some numbers on different lines, then press Ctrl-D to sum them up."
 
-    startNum = 0
-    sum = Task.loop! startNum addNumberFromStdin
-
+    sum = Task.loop! 0 addNumberFromStdin
     Stdout.line! "Sum: $(Num.toStr sum)"
 
 addNumberFromStdin : I64 -> Task [Done I64, Step I64] _
 addNumberFromStdin = \sum ->
-    when Stdin.line |> Task.result! is 
+    when Stdin.line |> Task.result! is
         Ok input ->
             when Str.toI64 input is
                 Ok num -> Task.ok (Step (sum + num))
                 Err _ -> Task.err (NotNum input)
+
         Err (StdinErr EndOfFile) -> Task.ok (Done sum)
         Err err -> err |> Inspect.toStr |> NotNum |> Task.err
 
 printErr : _ -> Task {} _
 printErr = \err ->
-    when err is 
+    when err is
         NotNum text -> Stderr.line "Error: \"$(text)\" is not a valid I64 number."
-        _ -> Stderr.line "Error: $(Inspect.toStr err)" 
-        
-    
+        _ -> Stderr.line "Error: $(Inspect.toStr err)"
+

--- a/examples/TaskLoop/main.roc
+++ b/examples/TaskLoop/main.roc
@@ -11,7 +11,8 @@ run : Task {} _
 run =
     Stdout.line! "Enter some numbers on different lines, then press Ctrl-D to sum them up."
 
-    sum = Task.loop! 0 addNumberFromStdin
+    startNum = 0
+    sum = Task.loop! startNum addNumberFromStdin
 
     Stdout.line! "Sum: $(Num.toStr sum)"
 

--- a/examples/Tasks/main.roc
+++ b/examples/Tasks/main.roc
@@ -15,11 +15,15 @@ run =
     startTime = Utc.now!
 
     # Read the HELLO environment variable
-    helloEnvVar = 
+    helloEnvVarStateStr = 
         readEnvVar "HELLO"
-        |> Task.map! \msg -> if Str.isEmpty msg then "was empty" else "was set to $(msg)"
+        |> Task.map! \envVarStr ->
+            if Str.isEmpty envVarStr then
+                "HELLO env var was empty."
+            else
+                "HELLO env var was set to $(envVarStr)."
 
-    Stdout.line! "HELLO env var $(helloEnvVar)"
+    Stdout.line! helloEnvVarStateStr
     
     # Read command line arguments
     { url, outputPath } = readArgs!

--- a/examples/Tasks/main.roc
+++ b/examples/Tasks/main.roc
@@ -1,56 +1,55 @@
 app "task-usage"
     packages { 
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br"
+        pf: "../../../basic-cli/platform/main.roc"
     }
     imports [ pf.Stdout, pf.Stderr, pf.Arg, pf.Env, pf.Http, pf.Dir, pf.Utc, pf.File, pf.Path.{ Path }, pf.Task.{ Task } ]
     provides [ main ] to pf
 
-run : Task {} Error
+main : Task {} _
+main = run |> Task.onErr handleErr
+
+run : Task {} _
 run =
 
     # Get time since [Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)
-    startTime <- Utc.now |> Task.await
+    startTime = Utc.now!
 
     # Read the HELLO environment variable
-    helloEnvVar <- readEnvVar "HELLO" |> Task.await
+    helloEnvVar = 
+        readEnvVar "HELLO"
+        |> Task.map! \msg -> if Str.isEmpty msg then "was empty" else "was set to $(msg)"
 
-    {} <- Stdout.line "HELLO env var was set to $(helloEnvVar)" |> Task.await
+    Stdout.line! "HELLO env var $(helloEnvVar)"
     
     # Read command line arguments
-    { url, outputPath } <- readArgs |> Task.await
+    { url, outputPath } = readArgs!
 
-    {} <- Stdout.line "Fetching content from $(url)..." |> Task.await
+    Stdout.line! "Fetching content from $(url)..."
     
     # Fetch the provided url using HTTP
-    strHTML <- fetchHtml url |> Task.await
+    strHTML = fetchHtml! url
 
-    {} <- Stdout.line "Saving url HTML to $(Path.display outputPath)..." |> Task.await
+    Stdout.line! "Saving url HTML to $(Path.display outputPath)..."
 
     # Write HTML string to a file
-    {} <- 
-       File.writeUtf8 outputPath strHTML
-       |> Task.onErr \_ -> Task.err (FailedToWriteFile outputPath)
-       |> Task.await
+    File.writeUtf8 outputPath strHTML
+    |> Task.onErr! \_ -> Task.err (FailedToWriteFile outputPath)
 
     # Print contents of current working directory
-    {} <- 
-        listCwdContent
-        |> Task.map \dirContents ->
-            List.map dirContents Path.display
-            |> Str.joinWith ","
-
-        |> Task.await \contentsStr ->
-            Stdout.line "Contents of current directory: $(contentsStr)"
-
-        |> Task.await 
+    listCwdContent
+    |> Task.map \dirContents ->
+        List.map dirContents Path.display
+        |> Str.joinWith ","
+    |> Task.await! \contentsStr ->
+        Stdout.line "Contents of current directory: $(contentsStr)"
     
-    endTime <- Utc.now |> Task.await
+    endTime = Utc.now!
     runTime = Utc.deltaAsMillis startTime endTime |> Num.toStr
 
-    {} <- Stdout.line "Run time: $(runTime) ms" |> Task.await
+    Stdout.line! "Run time: $(runTime) ms"
 
     # Final task doesn't need to be awaited
-    Stdout.line "Done"
+    Stdout.line! "Done"
 
 # NOTE in the future the trailing underscore `_` character will not be necessary.
 # This is a temporary workaround until [this issue](https://github.com/roc-lang/roc/issues/5660) 
@@ -58,30 +57,26 @@ run =
 
 readArgs : Task { url: Str, outputPath: Path } [FailedToReadArgs]_
 readArgs =
-    args <- Arg.list |> Task.attempt
-    
-    when args is
-        Ok ([ _, first, second, .. ]) ->
+    when Arg.list! is
+        [ _, first, second, .. ] ->
             Task.ok { url: first, outputPath: Path.fromStr second }
         _ ->
             Task.err FailedToReadArgs
 
-readEnvVar : Str -> Task Str *
+readEnvVar : Str -> Task Str []_
 readEnvVar = \envVarName ->
-    envVarResult <- Env.var envVarName |> Task.attempt
-
-    when envVarResult is
+    when Env.var envVarName |> Task.result! is
         Ok envVarStr if !(Str.isEmpty envVarStr) ->
             Task.ok envVarStr
         _ ->
             Task.ok ""
 
-fetchHtml : Str -> Task Str [FailedToFetchHtml Str]_
+fetchHtml : Str -> Task Str [FailedToFetchHtml _]_
 fetchHtml = \url ->
     { Http.defaultRequest & url } 
     |> Http.send 
     |> Task.await \resp -> resp |> Http.handleStringResponse |> Task.fromResult
-    |> Task.onErr \err -> Task.err (FailedToFetchHtml (Http.errorToString err))
+    |> Task.mapErr FailedToFetchHtml
 
 listCwdContent : Task (List Path) [FailedToListCwd]_
 listCwdContent = 
@@ -89,26 +84,16 @@ listCwdContent =
     |> Dir.list
     |> Task.onErr \_ -> Task.err FailedToListCwd
 
-main : Task {} *
-main =
-    run
-    |> Task.onErr handleErr
-
-Error : [
-    FailedToReadArgs,
-    FailedToFetchHtml Str,
-    FailedToWriteFile Path,
-    FailedToListCwd,
-]
-
-handleErr : Error -> Task {} *
+handleErr : _ -> Task {} _
 handleErr = \err ->
     usage = "HELLO=1 roc main.roc -- \"https://www.roc-lang.org\" roc.html"
 
-    errorMsg = when err is
-        FailedToReadArgs -> "Failed to read command line arguments, usage: $(usage)"
-        FailedToFetchHtml httpErr -> "Failed to fetch URL $(httpErr), usage: $(usage)"
-        FailedToWriteFile path -> "Failed to write to file $(Path.display path), usage: $(usage)"
-        FailedToListCwd -> "Failed to list contents of current directory, usage: $(usage)"
+    errorMsg = 
+        when err is
+            FailedToReadArgs -> "Failed to read command line arguments, usage: $(usage)"
+            FailedToFetchHtml httpErr -> "Failed to fetch URL $(Inspect.toStr httpErr), usage: $(usage)"
+            FailedToWriteFile path -> "Failed to write to file $(Path.display path), usage: $(usage)"
+            FailedToListCwd -> "Failed to list contents of current directory, usage: $(usage)"
+            _ -> Inspect.toStr err
 
-    Stderr.line "Error: $(errorMsg)"
+    Stderr.line! "Error: $(errorMsg)"

--- a/examples/Tasks/main.roc
+++ b/examples/Tasks/main.roc
@@ -1,6 +1,6 @@
 app "task-usage"
     packages {
-        pf: "../../../basic-cli/platform/main.roc",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
     }
     imports [pf.Stdout, pf.Stderr, pf.Arg, pf.Env, pf.Http, pf.Dir, pf.Utc, pf.File, pf.Path.{ Path }, pf.Task.{ Task }]
     provides [main] to pf

--- a/examples/Tuples/main.roc
+++ b/examples/Tuples/main.roc
@@ -1,5 +1,5 @@
 app "tuples-example"
-    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.1/y_Ww7a2_ZGjp0ZTt9Y_pNdSqqMRdMLzHMKfdN8LWidk.tar.br" }
+    packages { pf: "../../../basic-cli/platform/main.roc" }
     imports [
         pf.Stdout,
         pf.Task,
@@ -17,13 +17,12 @@ main =
     secondItem = if simpleTuple.1 then "true" else "false"
     thirdItem = Num.toStr simpleTuple.2
 
-    {} <- Stdout.line
-            """
-            First is: $(firstItem),
-            Second is: $(secondItem), 
-            Third is: $(thirdItem).
-            """
-        |> Task.await
+    Stdout.line!
+        """
+        First is: $(firstItem),
+        Second is: $(secondItem), 
+        Third is: $(thirdItem).
+        """
 
     # You can also use tuples with `when`:
     fruitSelection : [Apple, Pear, Banana]

--- a/examples/Tuples/main.roc
+++ b/examples/Tuples/main.roc
@@ -16,7 +16,6 @@ main =
     firstItem = simpleTuple.0
     secondItem = if simpleTuple.1 then "true" else "false"
     thirdItem = Num.toStr simpleTuple.2
-
     Stdout.line!
         """
         First is: $(firstItem),

--- a/examples/Tuples/main.roc
+++ b/examples/Tuples/main.roc
@@ -1,5 +1,5 @@
 app "tuples-example"
-    packages { pf: "../../../basic-cli/platform/main.roc" }
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br" }
     imports [
         pf.Stdout,
         pf.Task,

--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1713167721,
-        "narHash": "sha256-Jgi2paIVkaISKoRuNuf0QKuB+gmxtG7mD4rNNEuBlwI=",
+        "lastModified": 1714267049,
+        "narHash": "sha256-8RxtfW9vnFDy5nTGTh0O4afjG6d9GYtsJJDGClwOBHs=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "972b254ebd6d64ec14b26877e25b01567c0d6e5b",
+        "rev": "759e26ea13980f209e20507d493d61f040705ea8",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712973993,
-        "narHash": "sha256-ZJxC6t2K0UAPW+lV+bJ+pAtwbn29eqZQzXLTG54oL+I=",
+        "lastModified": 1714270637,
+        "narHash": "sha256-sq/0YEupY9yoRpg9ft8r2sjoRo84MQipionTuk4w1YI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a497535d074432133b683dda3a1faa8c8ab587ad",
+        "rev": "44f8738f4b9805f7c60118c48f85da835839311a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates the examples to use the latest `!` syntax

Before merging this PR requires 
- Merged https://github.com/roc-lang/roc/pull/6678
- Merged https://github.com/roc-lang/roc/pull/6676
- Merged https://github.com/roc-lang/basic-cli/pull/188
- New release of basic-cli and URL updated in examples