### PR TITLE
increase timeout .net expect script

### DIFF
--- a/ci_scripts/expect_scripts/DotNetPlatform.exp
+++ b/ci_scripts/expect_scripts/DotNetPlatform.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect
 
 # uncomment line below for debugging
-# exp_internal 1
+exp_internal 1
 
 set timeout 25
 

--- a/ci_scripts/expect_scripts/DotNetPlatform.exp
+++ b/ci_scripts/expect_scripts/DotNetPlatform.exp
@@ -1,9 +1,9 @@
 #!/usr/bin/expect
 
 # uncomment line below for debugging
-exp_internal 1
+# exp_internal 1
 
-set timeout 25
+set timeout 30
 
 cd "./examples/DotNetPlatform/platform/"
 


### PR DESCRIPTION
This was failing only on Ubuntu 20.04 on CI