### PR TITLE
Add Custom `Inspect` example for Opaque types

### DIFF
--- a/ci_scripts/all_tests.sh
+++ b/ci_scripts/all_tests.sh
@@ -91,6 +91,8 @@ go build -C examples/GoPlatform/platform -buildmode=pie -o dynhost
 $ROC preprocess-host ./examples/GoPlatform/platform/dynhost ./examples/GoPlatform/platform/main.roc ./examples/GoPlatform/platform/libapp.so
 $ROC build ./examples/GoPlatform/main.roc
 
+$ROC test ./examples/CustomInspect/OpaqueTypes.roc
+
 # temporarily allow failure of lsb_release in case it is not installed
 set +e
 os_info=$(lsb_release -a 2>/dev/null)

--- a/examples/CustomInspect/OpaqueTypes.roc
+++ b/examples/CustomInspect/OpaqueTypes.roc
@@ -24,8 +24,8 @@ expect Inspect.toStr (@Color Blue) == "\"_BLUE_\""
 
 ### start snippet secret
 MySecret := Str implements [
-    Inspect { toInspector: mySecretInspector },
-]
+        Inspect { toInspector: mySecretInspector },
+    ]
 
 mySecretInspector : MySecret -> Inspector f where f implements InspectFormatter
 mySecretInspector = \@MySecret _ -> Inspect.str "******* REDACTED *******"

--- a/examples/CustomInspect/OpaqueTypes.roc
+++ b/examples/CustomInspect/OpaqueTypes.roc
@@ -1,0 +1,34 @@
+module []
+
+### start snippet color
+Color := [
+    Red,
+    Green,
+    Blue,
+]
+    implements [
+        Inspect { toInspector: colorInspector },
+    ]
+
+colorInspector : Color -> Inspector f where f implements InspectFormatter
+colorInspector = \@Color color ->
+    when color is
+        Red -> Inspect.str "_RED_"
+        Green -> Inspect.str "_GREEN_"
+        Blue -> Inspect.str "_BLUE_"
+
+expect Inspect.toStr (@Color Red) == "\"_RED_\""
+expect Inspect.toStr (@Color Green) == "\"_GREEN_\""
+expect Inspect.toStr (@Color Blue) == "\"_BLUE_\""
+### end snippet color
+
+### start snippet secret
+MySecret := Str implements [
+    Inspect { toInspector: mySecretInspector },
+]
+
+mySecretInspector : MySecret -> Inspector f where f implements InspectFormatter
+mySecretInspector = \@MySecret _ -> Inspect.str "******* REDACTED *******"
+
+expect Inspect.toStr (@MySecret "password1234") == "\"******* REDACTED *******\""
+### end snippet secret

--- a/examples/CustomInspect/README.md
+++ b/examples/CustomInspect/README.md
@@ -2,7 +2,7 @@
 
 An [Opaque type](https://www.roc-lang.org/tutorial#opaque-types) can provide a custom implementation for the [Inspect](https://www.roc-lang.org/builtins/Inspect) ability.
 
-This can be useful for more complex types, or to hid internal implementation details.
+This can be useful for more complex types, or to hide internal implementation details.
 
 ## Simple Tag Union
 ```roc

--- a/examples/CustomInspect/README.md
+++ b/examples/CustomInspect/README.md
@@ -1,0 +1,15 @@
+# Custom Inspect
+
+An [Opaque type](https://www.roc-lang.org/tutorial#opaque-types) can provide a custom implementation for the [Inspect](https://www.roc-lang.org/builtins/Inspect) ability.
+
+This can be useful for more complex types, or to hid internal implementation details.
+
+## Simple Tag Union
+```roc
+file:OpaqueTypes.roc:snippet:color
+```
+
+## Redacting a Secret
+```roc
+file:OpaqueTypes.roc:snippet:secret
+```

--- a/examples/index.md
+++ b/examples/index.md
@@ -32,6 +32,7 @@ You can find the source code for all of these at [github.com/roc-lang/examples](
 - [Go Platform](/GoPlatform/README.html)
 - [.NET Platform](/DotNetPlatform/README.html)
 - [Elm Web App](/ElmWebApp/README.html)
+- [Custom Inspect](/CustomInspect/README.html)
 
 ## External examples
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -26,13 +26,13 @@ You can find the source code for all of these at [github.com/roc-lang/examples](
 - [Looping Tasks](/TaskLoop/README.html)
 - [Record Builder](/RecordBuilder/README.html)
 - [Encoding & Decoding Abilities](/EncodeDecode/README.html)
+- [Custom Inspect](/CustomInspect/README.html)
 - [Least Squares](/LeastSquares/README.html)
 - [Towers of Hanoi](/TowersOfHanoi/README.html)
 - [Multi-line Comments](/MultiLineComments/README.html)
 - [Go Platform](/GoPlatform/README.html)
 - [.NET Platform](/DotNetPlatform/README.html)
 - [Elm Web App](/ElmWebApp/README.html)
-- [Custom Inspect](/CustomInspect/README.html)
 
 ## External examples
 


### PR DESCRIPTION
It took me a while to find the correct syntax for this, so I made an example to help my future self and others implement a custom `Inspect` for an Opaque type.