### PR TITLE
Migrate examples HelloWeb and ElmWebApp

### DIFF
--- a/examples/ElmWebApp/README.md
+++ b/examples/ElmWebApp/README.md
@@ -35,15 +35,16 @@ file:backend.roc
 
 ### Roc
 
-You can change the port on which the Roc server runs with ROC_BASIC_WEBSERVER_PORT.
-```
+You can change the port on which the Roc server runs with `ROC_BASIC_WEBSERVER_PORT`.
+
+```bash
 cd examples/ElmWebApp/
 
 # development
-roc backend.roc --linker=legacy
+roc backend.roc
 
 # production
-roc build backend.roc --optimize --linker=legacy
+roc build --opt=speed backend.roc
 ./backend
 ```
 
@@ -52,7 +53,8 @@ roc build backend.roc --optimize --linker=legacy
 > Note: for non-trivial Elm development we recommend using [elm-watch](https://github.com/lydell/elm-watch).
 
 Compile elm code to javascript:
-```
+
+```bash
 cd examples/ElmWebApp/frontend
 # development
 elm make src/Main.elm --output elm.js
@@ -61,9 +63,12 @@ elm make src/Main.elm --output elm.js --optimize
 ```
 
 Serve the frontend:
+
+```bash
+# Roc backend will be on 8000
+elm reactor --port 8001
 ```
-elm reactor --port 8001 # Roc backend will be on 8000
-```
-For production; use a battle-tested HTTP server instead of elm reactor.
+
+For production; use a battle-tested HTTP server instead of `elm reactor`.
 
 Open [localhost:8001/index.html](localhost:8001/index.html) in your browser.

--- a/examples/ElmWebApp/backend.roc
+++ b/examples/ElmWebApp/backend.roc
@@ -1,39 +1,34 @@
-app [Model, init!, respond!] {
-    web: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.13.1/7P4PF5rntQVkys5JbIHqkMpZIXo-pxa5lVqOdh7z8fE.tar.br",
-    roc: "nightly-2026-08-10-7df8509",
+app [Context, program] {
+	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.16.0/42jC1JT3auhHSmv2Ah8mW5F2MXiAakq1UQQ4NQceQjXw.tar.zst",
+	http: "https://github.com/roc-lang/http/releases/download/2.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 }
 
-import web.Stdout
-import web.Http exposing [Request, Response]
-import web.Utc
+import pf.Server
+import http.Response
 
-# [backend](https://chatgpt.com/share/7ac35a32-dab5-46d0-bb17-9d584469556f) Roc server
+Context : {}
 
-# Model is produced by `init`.
-Model : {}
+program = { init!, respond!, shutdown! }
 
 # With `init` you can set up a database connection once at server startup,
 # generate css by running `tailwindcss`,...
-# In this case we don't have anything to initialize, so it is just `Ok({})`.
+# In this case we don't have anything to initialize, so we use the default
+# config
+init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
+init! = || Ok({ config: Server.default_config, context: {} })
 
-init! = |{}| Ok({})
+respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
+respond! = |_request, _context|
+	Ok(
+		Server.respond(
+			Response.from_status(200)
+			# !!
+			# Change http://localhost:8001 to your domain for production usage
+			# !!
+				.with_headers([{ name: "Access-Control-Allow-Origin", value: "http://localhost:8001" }])
+				.with_body(Str.to_utf8("Hi, Elm! This is from Roc: 🎁\n")),
+		),
+	)
 
-respond! : Request, Model => Result Response [ServerErr Str]_
-respond! = |req, _|
-    # Log request datetime, method and url
-    datetime = Utc.to_iso_8601(Utc.now!({}))
-
-    Stdout.line!("${datetime} ${Inspect.to_str(req.method)} ${req.uri}")?
-
-    Ok(
-        {
-            status: 200,
-            headers: [
-                # !!
-                # Change http://localhost:8001 to your domain for production usage
-                # !!
-                { name: "Access-Control-Allow-Origin", value: "http://localhost:8001" },
-            ],
-            body: Str.to_utf8("Hi, Elm! This is from Roc: 🎁\n"),
-        },
-    )
+shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
+shutdown! = |_reason, _context| Ok({})

--- a/examples/ElmWebApp/frontend/elm.json
+++ b/examples/ElmWebApp/frontend/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.2",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.2",

--- a/examples/HelloWeb/README.md
+++ b/examples/HelloWeb/README.md
@@ -1,6 +1,6 @@
 # Hello Web
 
-A webserver that serves one web page showing `Hello, web!` using the [basic-webserver platform](https://github.com/roc-lang/basic-webserver).
+A webserver that serves one web page showing `Hello from Roc!` using the [basic-webserver platform](https://github.com/roc-lang/basic-webserver).
 
 There are much more [basic-webserver examples](https://github.com/roc-lang/basic-webserver/tree/main/examples).
 
@@ -18,11 +18,16 @@ $ roc main.roc
 Listening on http://127.0.0.1:8000
 ```
 
+On Linux or macOS:
+
 - To change the port: `export ROC_BASIC_WEBSERVER_PORT=8888`
 - To change the host: `export ROC_BASIC_WEBSERVER_HOST=0.0.0.0`
 - To change the number of threads: `export TOKIO_WORKER_THREADS=4`
 
+On Windows, replace `export xxx=yyy` with `set xxx=yyy` (or `$env:xxx=yyy` in the Powershell).
+
 To optimize build:
 ```
-$ roc build --optimize main.roc --linker=legacy
+$ roc build --opt=speed --output=hello-web main.roc
+$ ./hello-web
 ```

--- a/examples/HelloWeb/main.roc
+++ b/examples/HelloWeb/main.roc
@@ -1,51 +1,31 @@
-## Uses host-owned operational telemetry and responds with a simple HTML greeting.
 app [Context, program] {
-	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.15.0/HcMFsVT26qeMvqWtG5rfNhVMWjceYbKh1An4uYpheBVW.tar.zst",
-	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-	gregorian: "https://cdn.jasperwoudenberg.com/roc-gregorian-v1.0.0-rc.2/Ce3xuHN92F5oGRuzjUTmm65jULAEj8pvvrTBmZJzE1M4.tar.zst",
-	roc: "nightly-2026-08-10-7df8509",
+	pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.16.0/42jC1JT3auhHSmv2Ah8mW5F2MXiAakq1UQQ4NQceQjXw.tar.zst",
+	http: "https://github.com/roc-lang/http/releases/download/2.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 }
-# app [Model, init!, respond!] {
-#    web: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.15.0/HcMFsVT26qeMvqWtG5rfNhVMWjceYbKh1An4uYpheBVW.tar.zst",
-#    http: "https://github.com/roc-lang/http/releases/download/2.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-# }
 
 import pf.Server
-import pf.Stdout
-import pf.UnixTime
 import http.Response
-import gregorian.Time
 
-# `init!` produces this immutable context once, and every request receives it.
 Context : {}
 
 program = { init!, respond!, shutdown! }
 
-# `init!` can validate configuration, run migrations, or prepare immutable
-# startup data. This example has no startup data, so its context is `{}`.
+# With `init` you can set up a database connection once at server startup,
+# generate css by running `tailwindcss`...
+# In this case we don't have anything to initialize, so we use the default
+# config.
 init! : () => Try({ config : Server.Config, context : Context }, [Exit(I64), ..])
-init! = || {
-	# TODO: simplify this. We don't need acces log, metrics... in hello web example.
-	config = Server.default_config
-		.with_access_log(
-			Server.json_lines_access_log({
-				target: Server.path_without_query,
-				max_buffered_events: 128,
-			}),
-		)
-		.with_metrics(Server.open_metrics({ at: "/metrics" }))
-	Ok({ config, context: {} })
-}
+init! = || Ok({ config: Server.default_config, context: {} })
 
 respond! : Server.Request, Context => Try(Server.Outcome, [ServerErr(Str), ..])
-respond! = |request, _context| {
-	datetime = (Time.unix_epoch + UnixTime.now!().seconds_since_epoch()).iso8601()
-
-	Stdout.line!("${datetime} ${Str.inspect(request.method())} ${Str.inspect(request.target())}")
-		? |err| ServerErr("Failed to log request: ${Str.inspect(err)}")
-
-	Ok(Server.respond(Response.from_status(200).with_body(Str.to_utf8("<b>Hello from server</b><br>"))))
-}
+respond! = |_request, _context|
+	Ok(
+		Server.respond(
+			Response.from_status(200)
+				.with_headers([{ name: "Content-Type", value: "text/html; charset=utf-8" }])
+				.with_body(Str.to_utf8("<b>Hello from Roc!</b>")),
+		),
+	)
 
 shutdown! : Server.ShutdownReason, Context => Try({}, [Exit(I64), ..])
 shutdown! = |_reason, _context| Ok({})


### PR DESCRIPTION
This PR ports the HelloWeb and ElmWebApp examples to the new Zig compiler and clarifies a couple things, such as how to set env vars on Windows.

Note: for users who just want to try out `elm` quickly without installing it, we could replace `elm` commands with `npx elm`. Wdyt? 