### PR TITLE
Update the AllSyntax example

### DIFF
--- a/ci_scripts/expect_scripts/AllSyntax.exp
+++ b/ci_scripts/expect_scripts/AllSyntax.exp
@@ -9,13 +9,13 @@ source ./ci_scripts/expect_scripts/shared-code.exp
 
 spawn ./examples/AllSyntax/main
 
-# 1. Used subst to evaluate \u00a0
+# 1. Used subst to evaluate \u2728
 # 2. Escaped glob brackets as \\[ and \\]
 # 3. Did NOT escape { and }, as they are not special in glob
 set expected_output [normalize_output [subst -nocommands -novariables {
 Hello, world!
 Hello, world! (using alias)
-{ diff: 5, div: 2, div_trunc: 2, eq: False, gt: True, gteq: True, lt: False, lteq: False, neg: -10, neq: True, prod: 50, rem: 0, sum: 15 }
+{ default: 0, diff: 5, div: 2, div_trunc: 2, eq: False, gt: True, gteq: True, lt: False, lteq: False, neg: -10, neq: True, prod: 50, rem: 0, sum: 15 }
 { bool_and_keyword: False, bool_or_keyword: True, not_a: False }
 "One Two"
 "Three Four"
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence: \u00a0
+Unicode escape sequence: \u2728
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))
@@ -43,6 +43,9 @@ NotOneTwoNotFive
 10.0
 { age: 31, name: "Alice" }
 { age: 30, name: "Alice" }
+"localhost:8080 (no timeout)"
+Err(MissingField)
+"example.com:80 (5000ms)"
 { binary: 5.0, explicit_i128: 5, explicit_i16: 5, explicit_i32: 5, explicit_i64: 5, explicit_i8: 5, explicit_u128: 5, explicit_u16: 5, explicit_u32: 5, explicit_u64: 5, explicit_u8: 5, hex: 5.0, octal: 5.0, usage_based: 5.0 }
 <opaque>
 "The secret key is: my_secret_key"

--- a/ci_scripts/expect_scripts/AllSyntax.exp
+++ b/ci_scripts/expect_scripts/AllSyntax.exp
@@ -9,7 +9,7 @@ source ./ci_scripts/expect_scripts/shared-code.exp
 
 spawn ./examples/AllSyntax/main
 
-# 1. Used subst to evaluate \U0001F680
+# 1. Used subst to evaluate \u2728
 # 2. Escaped glob brackets as \\[ and \\]
 # 3. Did NOT escape { and }, as they are not special in glob
 set expected_output [normalize_output [subst -nocommands -novariables {
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence: \U0001F680
+Unicode escape sequence: \u2728
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))

--- a/ci_scripts/expect_scripts/AllSyntax.exp
+++ b/ci_scripts/expect_scripts/AllSyntax.exp
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence: \xF0\x9F\x9A\x80
+Unicode escape sequence: \U0001F680
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))

--- a/ci_scripts/expect_scripts/AllSyntax.exp
+++ b/ci_scripts/expect_scripts/AllSyntax.exp
@@ -9,7 +9,7 @@ source ./ci_scripts/expect_scripts/shared-code.exp
 
 spawn ./examples/AllSyntax/main
 
-# 1. Used subst to evaluate \u2728
+# 1. Used subst to evaluate \U0001F680
 # 2. Escaped glob brackets as \\[ and \\]
 # 3. Did NOT escape { and }, as they are not special in glob
 set expected_output [normalize_output [subst -nocommands -novariables {
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence: \u2728
+Unicode escape sequence: \xF0\x9F\x9A\x80
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))

--- a/examples/AllSyntax/README.md
+++ b/examples/AllSyntax/README.md
@@ -15,7 +15,7 @@ Run this from the directory that has `main.roc` in it:
 $ roc main.roc
 Hello, world!
 Hello, world! (using alias)
-{ diff: 5, div: 2, div_trunc: 2, eq: False, gt: True, gteq: True, lt: False, lteq: False, neg: -10, neq: True, prod: 50, rem: 0, sum: 15 }
+{ default: 0, diff: 5, div: 2, div_trunc: 2, eq: False, gt: True, gteq: True, lt: False, lteq: False, neg: -10, neq: True, prod: 50, rem: 0, sum: 15 }
 { bool_and_keyword: False, bool_or_keyword: True, not_a: False }
 "One Two"
 "Three Four"
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence:  
+Unicode escape sequence: ✨
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))
@@ -33,7 +33,7 @@ Err(NoFirstError(ListWasEmpty))
 15.0
 False
 10.0
-[dbg] 42.0
+[dbg] 42.0 <= this is output to stderr
 42.0
 NotOneTwoNotFive
 ("Roc", 1.0)
@@ -43,7 +43,10 @@ NotOneTwoNotFive
 10.0
 { age: 31, name: "Alice" }
 { age: 30, name: "Alice" }
-{ binary: 5.0, explicit_i128: 5, explicit_i16: 5, explicit_i32: 5, explicit_i64: 5, explicit_i8: 5, explicit_u128: 5, explicit_u16: 5, explicit_u32:5, explicit_u64: 5, explicit_u8: 5, hex: 5.0, octal: 5.0, usage_based: 5.0 }
+"localhost:8080 (no timeout)"
+Err(MissingField)
+"example.com:80 (5000ms)"
+{ binary: 5.0, explicit_i128: 5, explicit_i16: 5, explicit_i32: 5, explicit_i64: 5, explicit_i8: 5, explicit_u128: 5, explicit_u16: 5, explicit_u32: 5, explicit_u64: 5, explicit_u8: 5, hex: 5.0, octal: 5.0, usage_based: 5.0 }
 <opaque>
 "The secret key is: my_secret_key"
 False

--- a/examples/AllSyntax/README.md
+++ b/examples/AllSyntax/README.md
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence: 🚀
+Unicode escape sequence: ✨
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))

--- a/examples/AllSyntax/README.md
+++ b/examples/AllSyntax/README.md
@@ -25,7 +25,7 @@ Success
 Line 1
 Line 2
 Line 3
-Unicode escape sequence: ✨
+Unicode escape sequence: 🚀
 This is an effectful function!
 Ok(1)
 Err(NoFirstError(ListWasEmpty))

--- a/examples/AllSyntax/README.md
+++ b/examples/AllSyntax/README.md
@@ -33,7 +33,7 @@ Err(NoFirstError(ListWasEmpty))
 15.0
 False
 10.0
-[dbg] 42.0 <= this is output to stderr
+[dbg] 42.0
 42.0
 NotOneTwoNotFive
 ("Roc", 1.0)
@@ -60,3 +60,4 @@ False
 True
 ```
 
+Note: the `[dbg]` line is output to stderr instead of stdout.

--- a/examples/AllSyntax/main.roc
+++ b/examples/AllSyntax/main.roc
@@ -395,7 +395,7 @@ main! = |_args| {
 	echo!("${match_tag_union_advanced(Ok({}))}\n")
 
 	echo!("${multiline_str(3)}\n")
-	echo!("Unicode escape sequence: \u(2728)\n")
+	echo!("Unicode escape sequence: \u(1F680)\n")
 
 	effect_demo!("This is an effectful function!")
 

--- a/examples/AllSyntax/main.roc
+++ b/examples/AllSyntax/main.roc
@@ -24,8 +24,8 @@ number_operators = |a, b| {
 		gt: a > b,
 		gteq: a >= b,
 
-		# Not implemented yet:
-		# default: None ?? 0,
+		# `??` to provide a default value in case of `Err`.
+		default: I64.from_str("not a number") ?? 0,
 
 		# unary operators
 		neg: -a,
@@ -256,6 +256,23 @@ remove_record_field = |person| {
 	rest
 }
 
+# A record type field can have a default value (`field : Type ?? default`) or be
+# optional (`field ?: Type`). Both let you leave the field out when you build the record.
+# A defaulted field is always there when you read it, so you read it with plain `.field`.
+# An optional field may be missing, so you read it with `.?field`, which gives you a `Try`.
+ServerConfig : { host : Str, port : U16 ?? 8080, timeout_ms ?: U64 }
+
+describe_config : ServerConfig -> Str
+describe_config = |config| {
+	timeout_str = match config.?timeout_ms {
+		Ok(ms) => "${ms.to_str()}ms"
+		Err(MissingField) => "no timeout"
+	}
+
+	# `config.port` needs no unwrapping, it's the default when it wasn't provided
+	"${config.host}:${config.port.to_str()} (${timeout_str})"
+}
+
 number_literals = {
 	usage_based: 5, # defaults to Dec
 	explicit_u8: 5.U8, # Note that most of the time you will want to specify the type in the type signature instead.
@@ -366,11 +383,11 @@ main! = |_args| {
 	echo!("${Str.inspect(number_operators(10, 5))}\n")
 	print!(boolean_operators(Bool.True, Bool.False))
 
-	# pizza operator (|>) is gone, we now have static dispatch instead.
-	# It allows you to call methods that are defined on the type (like `Animal.is_eq` above).
+	# `.` (Static Dispatch) allows you to call methods that are defined on the type,
+	# like Str.concat below, or Animal.is_eq above
 	print!("One".concat(" Two"))
 
-	# If you want a very similar style for a function that is not defined on the type but is in scope, you can use `|>`:
+	# If you want a very similar style for a function that is not defined on the type but is in scope, you can use `|>` (Pizza Operator):
 	print!("Three" |> my_concat(" Four"))
 
 	echo!("${simple_match(Red)}\n")
@@ -378,7 +395,7 @@ main! = |_args| {
 	echo!("${match_tag_union_advanced(Ok({}))}\n")
 
 	echo!("${multiline_str(3)}\n")
-	echo!("Unicode escape sequence: \u(00A0)\n")
+	echo!("Unicode escape sequence: \u(2728)\n")
 
 	effect_demo!("This is an effectful function!")
 
@@ -416,6 +433,22 @@ main! = |_args| {
 	print!(record_update_2({ name: "Alice", age: 30 }))
 
 	print!(remove_record_field({ name: "Alice", age: 30, email: "alice@example.com" }))
+
+	# We only provide `host`, so `port` falls back to its default and `timeout_ms` is missing.
+	minimal_config : ServerConfig
+	minimal_config = { host: "localhost" }
+	print!(describe_config(minimal_config))
+
+	# Reading an optional field that was not provided gives `Err(MissingField)`.
+	print!(minimal_config.?timeout_ms)
+	expect minimal_config.?timeout_ms == Err(MissingField)
+	expect minimal_config.port == 8080
+
+	# Here we do provide all fields, so `.?timeout_ms` is an `Ok`.
+	full_config : ServerConfig
+	full_config = { host: "example.com", port: 80, timeout_ms: 5000 }
+	print!(describe_config(full_config))
+	expect full_config.?timeout_ms == Ok(5000)
 
 	print!(number_literals)
 

--- a/examples/AllSyntax/main.roc
+++ b/examples/AllSyntax/main.roc
@@ -395,7 +395,7 @@ main! = |_args| {
 	echo!("${match_tag_union_advanced(Ok({}))}\n")
 
 	echo!("${multiline_str(3)}\n")
-	echo!("Unicode escape sequence: \u(1F680)\n")
+	echo!("Unicode escape sequence: \u(2728)\n")
 
 	effect_demo!("This is an effectful function!")
 


### PR DESCRIPTION
Updated to the [latest version from roc-lang/roc](https://github.com/roc-lang/roc/blob/main/test/echo/all_syntax_test.roc).

Also changed the unicode character escape sequence example to a visible character, or else it looks like a bug.